### PR TITLE
Update kibana to 7.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-ARG KIBANA_VERSION=7.4.1
+ARG KIBANA_VERSION=7.5.1
 
 ###############################################################################
 #                                INSTALLATION
@@ -85,14 +85,14 @@ RUN set -x \
   && cd /nodegit \
   && wget https://github.com/fg2it/phantomjs-on-raspberry/releases/download/v2.1.1-wheezy-jessie-armv6/phantomjs \
   && export PATH=$PATH:/nodegit:/opt/kibana/node/bin/ \
-  && chmod -R 777 /nodegit \
-  && /opt/kibana/node/bin/npm install --unsafe-perm ; fi
+  && chmod -R 777 /nodegit ; fi
+  # && /opt/kibana/node/bin/npm install --unsafe-perm ; fi
 
-RUN set -x \
-  && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ] ; then mv /opt/kibana/node_modules/@elastic/nodegit/build/Release /opt/kibana/node_modules/@elastic/nodegit/build/Release.old \
-  && mv /opt/kibana/node_modules/@elastic/nodegit/dist/enums.js /opt/kibana/node_modules/@elastic/nodegit/dist/enums.js.old \
-  && cp -rf /nodegit/build/Release /opt/kibana/node_modules/@elastic/nodegit/build \
-  && cp /nodegit/dist/enums.js /opt/kibana/node_modules/@elastic/nodegit/dist ; fi
+# RUN set -x \
+#   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ] ; then mv /opt/kibana/node_modules/@elastic/nodegit/build/Release /opt/kibana/node_modules/@elastic/nodegit/build/Release.old \
+#   && mv /opt/kibana/node_modules/@elastic/nodegit/dist/enums.js /opt/kibana/node_modules/@elastic/nodegit/dist/enums.js.old \
+#   && cp -rf /nodegit/build/Release /opt/kibana/node_modules/@elastic/nodegit/build \
+#   && cp /nodegit/dist/enums.js /opt/kibana/node_modules/@elastic/nodegit/dist ; fi
 
 RUN set -x \
   && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ] ; then cd /nodegit \ 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,7 @@ This may be resolved simply by adding configuration in filebeat to setup index t
 
 1. Tweak the `apt install` blocks.  I had to break them apart while debugging hanging build.
 
-2. Evaluate options to speed up build.  npm build of `nodegit` and `ctags` take very long, potential options include:
-
-    * Extracting / caching the compiled `nodegit` and `ctags` download the cached binaries during build.
-
-    * Investigate if bumping Kibana to newer version would eliminate the dependencies.  See post regarding this topic <https://discuss.elastic.co/t/installing-kibana-on-a-raspberry-pi-4-using-raspbian-buster/202612/7>
-
-3. Break the dockerfile into multistage build, push builder stage as described here: <https://pythonspeed.com/articles/faster-multi-stage-builds/>
+2. Break the dockerfile into multistage build, push builder stage as described here: <https://pythonspeed.com/articles/faster-multi-stage-builds/>
 
 ## How to Build
 


### PR DESCRIPTION
Update kibana to 7.5.1.  nodegit dependency not longer used in Kibana; remove notegit compiliation for arm